### PR TITLE
Removed superfluous calls to ToList()

### DIFF
--- a/RTree/RTree.cs
+++ b/RTree/RTree.cs
@@ -36,12 +36,12 @@ namespace RTree
 		}
 
         public IEnumerable<T> Search() {
-            return GetAllChildren(this.root).ToList();
+            return GetAllChildren(this.root);
         }
 
 		public IEnumerable<T> Search(Envelope boundingBox)
 		{
-			return DoSearch(boundingBox).Select(x => (T)x.Peek()).ToList();
+			return DoSearch(boundingBox).Select(x => (T)x.Peek());
 		}
 
 		public void Insert(T item)


### PR DESCRIPTION
There are a couple of calls that convert an IEnumerable to a list before returning an IEnumerable.